### PR TITLE
fix FPU control preventing compilation on ARM CPUs

### DIFF
--- a/parallel/Main.cc
+++ b/parallel/Main.cc
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
         setUsageHelp("c USAGE: %s [options] <input-file> <result-output-file>\n\n  where input may be either in plain or gzipped DIMACS.\n");
         // printf("This is MiniSat 2.0 beta\n");
         
-#if defined(__linux__)
+#if defined(__linux__) && (defined(__i386__) || defined(__x86_64__))
         fpu_control_t oldcw, newcw;
         _FPU_GETCW(oldcw); newcw = (oldcw & ~_FPU_EXTENDED) | _FPU_DOUBLE; _FPU_SETCW(newcw);
         printf("c WARNING: for repeatability, setting FPU to use double precision\n");

--- a/simp/Main.cc
+++ b/simp/Main.cc
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
       setUsageHelp("c USAGE: %s [options] <input-file> <result-output-file>\n\n  where input may be either in plain or gzipped DIMACS.\n");
 
 
-#if defined(__linux__)
+#if defined(__linux__) && (defined(__i386__) || defined(__x86_64__))
         fpu_control_t oldcw, newcw;
         _FPU_GETCW(oldcw); newcw = (oldcw & ~_FPU_EXTENDED) | _FPU_DOUBLE; _FPU_SETCW(newcw);
         //printf("c WARNING: for repeatability, setting FPU to use double precision\n");


### PR DESCRIPTION
There was a problem with compilation on arm CPUs on Linux, since the FPU control is specific to x86 architecture. I've added a condition that this is not applied when compiled on arm.